### PR TITLE
FEAT: Drawer 기능

### DIFF
--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -2,6 +2,7 @@
 import { css } from "@emotion/react";
 import { Routes, Route } from "react-router-dom";
 import AutoCompleteDescription from "../features/AutoComplete/AutoCompleteDescription";
+import DrawerDescription from "../features/Drawer/DrawerDescription";
 import DropDownDescription from "../features/DropDown/DropDownDescription";
 import ModalDescription from "../features/Modal/ModalDescription";
 import TabsDescription from "../features/Tabs/TabsDescription";
@@ -26,6 +27,7 @@ const Article = () => {
         <Route path="/Toggle" element={<ToggleDescription />} />
         <Route path="/AutoComplete" element={<AutoCompleteDescription />} />
         <Route path="/DropDown" element={<DropDownDescription />} />
+        <Route path="/Drawer" element={<DrawerDescription />} />
       </Routes>
     </div>
   );

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -7,7 +7,15 @@ const contaniner = css`
   height: 100%;
 `;
 
-const features = ["Modal", "Tabs", "Tag", "Toggle", "AutoComplete", "Dropdown"];
+const features = [
+  "Modal",
+  "Tabs",
+  "Tag",
+  "Toggle",
+  "AutoComplete",
+  "Dropdown",
+  "Drawer",
+];
 
 const Nav = () => {
   return (

--- a/src/features/Drawer/BottomDrawerDemo.tsx
+++ b/src/features/Drawer/BottomDrawerDemo.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useState } from "react";
+import { lightColor } from "../../styled";
+import { DrawerProps } from "./DrawerDescription";
+
+const button = css`
+  width: 100px;
+  height: 50px;
+  border: none;
+  color: white;
+  background-color: ${lightColor};
+`;
+
+const drawer = (isDrawerOn: boolean, height?: number) => css`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  height: ${height}px;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  transform: ${isDrawerOn ? "translate(0,0)" : "translate(0,100%)"};
+  transition: 0.3s;
+  z-index: 100;
+`;
+
+const dim = css`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 50;
+`;
+
+const BottomDrawerDemo: React.FC<DrawerProps> = ({
+  title,
+  height,
+  children,
+}) => {
+  const [isDrawerOn, setIsDrawerOn] = useState(false);
+
+  const handleDrawerOpen = () => {
+    setIsDrawerOn(true);
+  };
+  const handleDrawerClose = () => {
+    setIsDrawerOn(false);
+  };
+
+  return (
+    <>
+      <button css={button} onClick={handleDrawerOpen}>
+        {title}
+      </button>
+      <section css={drawer(isDrawerOn, height)}>{children}</section>
+      {isDrawerOn ? <div css={dim} onClick={handleDrawerClose} /> : null}
+    </>
+  );
+};
+
+export default BottomDrawerDemo;

--- a/src/features/Drawer/ChildrenExample.tsx
+++ b/src/features/Drawer/ChildrenExample.tsx
@@ -1,0 +1,35 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { darkColor, lightColor } from "../../styled";
+
+const container = css`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  div {
+    flex-grow: 1;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid black;
+    font-size: 24px;
+    color: white;
+    background-color: ${lightColor};
+    :hover {
+      background-color: ${darkColor};
+      cursor: pointer;
+    }
+  }
+`;
+
+const items = ["item1", "item2", "item3", "item4", "item5"];
+
+export const children = (
+  <div css={container}>
+    {items.map((item, index) => (
+      <div key={index}>{item}</div>
+    ))}
+  </div>
+);

--- a/src/features/Drawer/DrawerDescription.tsx
+++ b/src/features/Drawer/DrawerDescription.tsx
@@ -1,0 +1,34 @@
+/** @jsxImportSource @emotion/react */
+import { descContainer } from "../../styled";
+import TopDrawerDemo from "./TopDrawerDemo";
+import RightDrawerDemo from "./RightDrawerDemo";
+import BottomDrawerDemo from "./BottomDrawerDemo";
+import LeftDrawerDemo from "./LeftDrawerDemo";
+import { children } from "./ChildrenExample";
+
+export interface DrawerProps extends React.HTMLAttributes<any> {
+  title: string;
+  width?: number;
+  height?: number;
+}
+
+const DrawerDescription = () => {
+  return (
+    <div css={descContainer}>
+      <TopDrawerDemo title="TopDrawer" height={300}>
+        {children}
+      </TopDrawerDemo>
+      <RightDrawerDemo title="RightDrawer" width={100}>
+        {children}
+      </RightDrawerDemo>
+      <BottomDrawerDemo title="BottomDrawer" height={200}>
+        {children}
+      </BottomDrawerDemo>
+      <LeftDrawerDemo title="LefttDrawer" width={300}>
+        {children}
+      </LeftDrawerDemo>
+    </div>
+  );
+};
+
+export default DrawerDescription;

--- a/src/features/Drawer/LeftDrawerDemo.tsx
+++ b/src/features/Drawer/LeftDrawerDemo.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useState } from "react";
+import { lightColor } from "../../styled";
+import { DrawerProps } from "./DrawerDescription";
+
+const button = css`
+  width: 100px;
+  height: 50px;
+  border: none;
+  color: white;
+  background-color: ${lightColor};
+`;
+
+const drawer = (isDrawerOn: boolean, width?: number) => css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: ${width}px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  transform: ${isDrawerOn ? "translate(0,0)" : "translate(-100%,0)"};
+  transition: 0.3s;
+  z-index: 100;
+`;
+
+const dim = css`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 50;
+`;
+
+const RightDrawerDemo: React.FC<DrawerProps> = ({ title, width, children }) => {
+  const [isDrawerOn, setIsDrawerOn] = useState(false);
+
+  const handleDrawerOpen = () => {
+    setIsDrawerOn(true);
+  };
+  const handleDrawerClose = () => {
+    setIsDrawerOn(false);
+  };
+
+  return (
+    <>
+      <button css={button} onClick={handleDrawerOpen}>
+        {title}
+      </button>
+      <section css={drawer(isDrawerOn, width)}>{children}</section>
+      {isDrawerOn ? <div css={dim} onClick={handleDrawerClose} /> : null}
+    </>
+  );
+};
+export default RightDrawerDemo;

--- a/src/features/Drawer/RightDrawerDemo.tsx
+++ b/src/features/Drawer/RightDrawerDemo.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useState } from "react";
+import { lightColor } from "../../styled";
+import { DrawerProps } from "./DrawerDescription";
+
+const button = css`
+  width: 100px;
+  height: 50px;
+  border: none;
+  color: white;
+  background-color: ${lightColor};
+`;
+
+const drawer = (isDrawerOn: boolean, width?: number) => css`
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: ${width}px;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  transform: ${isDrawerOn ? "translate(0,0)" : "translate(100%,0)"};
+  transition: 0.3s;
+  z-index: 100;
+`;
+
+const dim = css`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 50;
+`;
+
+const RightDrawerDemo: React.FC<DrawerProps> = ({ title, width, children }) => {
+  const [isDrawerOn, setIsDrawerOn] = useState(false);
+
+  const handleDrawerOpen = () => {
+    setIsDrawerOn(true);
+  };
+  const handleDrawerClose = () => {
+    setIsDrawerOn(false);
+  };
+
+  return (
+    <>
+      <button css={button} onClick={handleDrawerOpen}>
+        {title}
+      </button>
+      <section css={drawer(isDrawerOn, width)}>{children}</section>
+      {isDrawerOn ? <div css={dim} onClick={handleDrawerClose} /> : null}
+    </>
+  );
+};
+export default RightDrawerDemo;

--- a/src/features/Drawer/TopDrawerDemo.tsx
+++ b/src/features/Drawer/TopDrawerDemo.tsx
@@ -1,0 +1,60 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useState } from "react";
+import { lightColor } from "../../styled";
+import { DrawerProps } from "./DrawerDescription";
+
+const button = css`
+  width: 100px;
+  height: 50px;
+  border: none;
+  color: white;
+  background-color: ${lightColor};
+`;
+
+const drawer = (isDrawerOn: boolean, height?: number) => css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: ${height}px;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  transform: ${isDrawerOn ? "translate(0,0)" : "translate(0,-100%)"};
+  transition: 0.3s;
+  z-index: 100;
+`;
+
+const dim = css`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 50;
+`;
+
+const TopDrawerDemo: React.FC<DrawerProps> = ({ title, height, children }) => {
+  const [isDrawerOn, setIsDrawerOn] = useState(false);
+
+  const handleDrawerOpen = () => {
+    setIsDrawerOn(true);
+  };
+  const handleDrawerClose = () => {
+    setIsDrawerOn(false);
+  };
+
+  return (
+    <>
+      <button css={button} onClick={handleDrawerOpen}>
+        {title}
+      </button>
+      <section css={drawer(isDrawerOn, height)}>{children}</section>
+      {isDrawerOn ? <div css={dim} onClick={handleDrawerClose} /> : null}
+    </>
+  );
+};
+
+export default TopDrawerDemo;

--- a/src/features/Modal/ModalDescription.tsx
+++ b/src/features/Modal/ModalDescription.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import { useState } from "react";
-import ModalDemo from "./ModalDemo";
 import { descContainer, mainColor, darkColor } from "../../styled";
+import ModalDemo from "./ModalDemo";
 
 const style = {
   button: css`


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
features-> main

### 변경 사항
1. FEAT: Drawer 기능
![Drawer](https://user-images.githubusercontent.com/84559872/168035517-eaf83662-58c2-4fa1-900a-b35531c0eab6.gif)
뱡향 이름을 가진 버튼을 누르면, 해당 방향에서 Drawer가 구현됩니다.
props로 버튼의 이름을 수정할 수 있는 title, 높이 및 넒이를 지정할 수 있는 height, width가 존재합니다.
또한, 해당 Drawer 내에 자식 컴포넌트를 내려 줄 수 있는 children이 존재합니다.
