### PR TITLE
Feat: Toast 기능

### DIFF
--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -8,6 +8,7 @@ import ModalDescription from "../features/Modal/ModalDescription";
 import TabsDescription from "../features/Tabs/TabsDescription";
 import TagDescription from "../features/Tag/TagDescription";
 import ToggleDescription from "../features/Toggle/ToggleDescription";
+import ToastDescription from "../features/Toast/ToastDescription";
 import Intro from "./Intro";
 
 const container = css`
@@ -28,6 +29,7 @@ const Article = () => {
         <Route path="/AutoComplete" element={<AutoCompleteDescription />} />
         <Route path="/DropDown" element={<DropDownDescription />} />
         <Route path="/Drawer" element={<DrawerDescription />} />
+        <Route path="/Toast" element={<ToastDescription />} />
       </Routes>
     </div>
   );

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import Item from "./Item";
 
 const contaniner = css`
-  width: 300px;
+  min-width: 300px;
   height: 100%;
 `;
 
@@ -15,6 +15,7 @@ const features = [
   "AutoComplete",
   "Dropdown",
   "Drawer",
+  "Toast",
 ];
 
 const Nav = () => {

--- a/src/features/Toast/PositionedToastDemo.tsx
+++ b/src/features/Toast/PositionedToastDemo.tsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleXmark } from "@fortawesome/free-solid-svg-icons";
+
+const container = (width: number, color: string, open: boolean) => css`
+  position: fixed;
+  bottom: 20%;
+  width: ${width}px;
+  height: 50px;
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  background-color: ${color};
+  color: white;
+  opacity: ${open ? "1" : "0"};
+  transition: 0.3s;
+`;
+
+const iconWrapper = css`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export interface ToastProps {
+  width: number;
+  description: string;
+  color: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const PositionedToastDemo = ({
+  width,
+  description,
+  color,
+  open,
+  onClose,
+}: ToastProps) => {
+  return (
+    <div css={container(width, color, open)}>
+      <div css={iconWrapper} onClick={onClose}>
+        <FontAwesomeIcon icon={faCircleXmark} style={{ cursor: "pointer" }} />
+      </div>
+      <span>{description}</span>
+    </div>
+  );
+};
+export default PositionedToastDemo;

--- a/src/features/Toast/SlideToastDemo.tsx
+++ b/src/features/Toast/SlideToastDemo.tsx
@@ -1,0 +1,50 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleXmark } from "@fortawesome/free-solid-svg-icons";
+
+const container = (width: number, color: string, open: boolean) => css`
+  position: fixed;
+  bottom: 20%;
+  right: 0;
+  width: ${width}px;
+  height: 50px;
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  background-color: ${color};
+  color: white;
+  transform: ${open ? "translate(0, 0)" : "translate(100%, 0)"};
+  transition: 0.3s;
+`;
+
+const iconWrapper = css`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export interface ToastProps {
+  width: number;
+  description: string;
+  color: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const SlideToastDemo = ({
+  width,
+  description,
+  color,
+  open,
+  onClose,
+}: ToastProps) => {
+  return (
+    <div css={container(width, color, open)}>
+      <div css={iconWrapper} onClick={onClose}>
+        <FontAwesomeIcon icon={faCircleXmark} style={{ cursor: "pointer" }} />
+      </div>
+      <span>{description}</span>
+    </div>
+  );
+};
+export default SlideToastDemo;

--- a/src/features/Toast/ToastDescription.tsx
+++ b/src/features/Toast/ToastDescription.tsx
@@ -1,0 +1,65 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { descContainer, lightColor } from "../../styled";
+import { useState } from "react";
+import SlideToastDemo from "./SlideToastDemo";
+import PositionedToastDemo from "./PositionedToastDemo";
+
+const button = css`
+  width: 150px;
+  height: 50px;
+  margin: 10px;
+  border: none;
+  border-radius: 10px;
+  background-color: ${lightColor};
+  color: white;
+`;
+
+const ToastDescription = () => {
+  const [isSlideToastOn, setIsSlideToastOn] = useState(false);
+
+  const slideToastOpen = () => {
+    setIsSlideToastOn(true);
+  };
+
+  const slideToastClose = () => {
+    setIsSlideToastOn(false);
+  };
+
+  const [isPositionedToastOn, setIsPositionedToastOn] = useState(false);
+
+  const positionedToastOpen = () => {
+    setIsPositionedToastOn(true);
+  };
+
+  const positionedToastClose = () => {
+    setIsPositionedToastOn(false);
+  };
+
+  return (
+    <div css={descContainer}>
+      <button css={button} onClick={slideToastOpen}>
+        slideToast
+      </button>
+      <button css={button} onClick={positionedToastOpen}>
+        positionedToast
+      </button>
+      <SlideToastDemo
+        width={200}
+        description="slide Toast!"
+        color="black"
+        open={isSlideToastOn}
+        onClose={slideToastClose}
+      />
+      <PositionedToastDemo
+        width={300}
+        description="This Toast is positioned."
+        color="blue"
+        open={isPositionedToastOn}
+        onClose={positionedToastClose}
+      />
+    </div>
+  );
+};
+
+export default ToastDescription;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
features -> main

### 변경 사항
1. Feat: Toast 기능
slideToast 버튼을 누르면, 우측 아래에서 Toast가 미끄러지면서 구현됩니다.
positionedToast 버튼을 누르면, 중앙 아래 부분에서 Toast가 구현됩니다.
props로 Toast의 내용을 수정할 수 있는 description, 색상을 정하는 color, 폭을 지정할 수 있는 width가 존재합니다.
해당 Toast 기능을 이용하기 위해서는 open props에 Toast 구현 유무를 정하는 상태값을 내려줘야 합니다.  ex) open={open}