### PR TITLE
Feat: SkeletonUI 기능 / Refactor: Modal props 이름 변경

### DIFF
--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -10,6 +10,7 @@ import TagDescription from "../features/Tag/TagDescription";
 import ToggleDescription from "../features/Toggle/ToggleDescription";
 import ToastDescription from "../features/Toast/ToastDescription";
 import Intro from "./Intro";
+import SkeletonUIDescription from "../features/SkeletonUI/SkeletonUIDescription";
 
 const container = css`
   display: flex;
@@ -30,6 +31,7 @@ const Article = () => {
         <Route path="/DropDown" element={<DropDownDescription />} />
         <Route path="/Drawer" element={<DrawerDescription />} />
         <Route path="/Toast" element={<ToastDescription />} />
+        <Route path="/SkeletonUI" element={<SkeletonUIDescription />} />
       </Routes>
     </div>
   );

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -16,6 +16,7 @@ const features = [
   "Dropdown",
   "Drawer",
   "Toast",
+  "SkeletonUI",
 ];
 
 const Nav = () => {

--- a/src/features/Modal/ModalDemo.tsx
+++ b/src/features/Modal/ModalDemo.tsx
@@ -40,16 +40,16 @@ const description = css`
 `;
 
 type ModalProps = {
-  isOpen: boolean;
-  handleClose: () => void;
+  open: boolean;
+  onClose: () => void;
 };
 
-const ModalDemo = ({ isOpen, handleClose }: ModalProps) => {
-  return isOpen ? (
+const ModalDemo = ({ open, onClose }: ModalProps) => {
+  return open ? (
     <>
       <div css={dim} />
       <section css={box}>
-        <div css={closeBox} onClick={handleClose}>
+        <div css={closeBox} onClick={onClose}>
           <FontAwesomeIcon icon={faCircleXmark} />
         </div>
         <div css={title}>

--- a/src/features/Modal/ModalDescription.tsx
+++ b/src/features/Modal/ModalDescription.tsx
@@ -32,7 +32,7 @@ const ModalDescription = () => {
 
   return (
     <div css={descContainer}>
-      <ModalDemo isOpen={isOpen} handleClose={handleClose} />
+      <ModalDemo open={isOpen} onClose={handleClose} />
       <button css={style.button} onClick={handleOpen}>
         modal
       </button>

--- a/src/features/SkeletonUI/SkeletonUIDemo.tsx
+++ b/src/features/SkeletonUI/SkeletonUIDemo.tsx
@@ -1,0 +1,32 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css, keyframes } from "@emotion/react";
+
+const animation = keyframes`
+  0% {
+    background-color: rgba(165,165,165,0.1);
+  }
+  50% {
+    background-color: rgba(165,165,165,0.3);
+  }
+  100% {
+    background-color: rgba(165,165,165,0.1);
+  }
+`;
+
+const container = css`
+  > * {
+    animation: ${animation};
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+  }
+`;
+
+interface SkeletonUIProps extends React.HTMLAttributes<any> {}
+
+const SkeletonUIDemo: React.FC<SkeletonUIProps> = ({ children }) => {
+  return <div css={container}>{children}</div>;
+};
+
+export default SkeletonUIDemo;

--- a/src/features/SkeletonUI/SkeletonUIDescription.tsx
+++ b/src/features/SkeletonUI/SkeletonUIDescription.tsx
@@ -1,0 +1,55 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { descContainer } from "../../styled";
+import SkeletonUIDemo from "./SkeletonUIDemo";
+
+const layout = css`
+  width: 500px;
+  height: 500px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  justify-items: center;
+  align-items: center;
+  font-size: 24px;
+  box-sizing: border-box;
+`;
+
+const rectangleExample = css`
+  width: 200px;
+  height: 50px;
+`;
+
+const squareExample = css`
+  width: 100px;
+  height: 100px;
+`;
+
+const circleExample = css`
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+`;
+
+const SkeletonUIDescription = () => {
+  return (
+    <div css={descContainer}>
+      <section css={layout}>
+        Rectangle :
+        <SkeletonUIDemo>
+          <div css={rectangleExample}></div>
+        </SkeletonUIDemo>
+        Square :
+        <SkeletonUIDemo>
+          <div css={squareExample}></div>
+        </SkeletonUIDemo>
+        Circle :
+        <SkeletonUIDemo>
+          <div css={circleExample}></div>
+        </SkeletonUIDemo>
+      </section>
+    </div>
+  );
+};
+
+export default SkeletonUIDescription;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링

### 반영 브랜치
features -> main

### 변경 사항
1. Feat: SkeletonUI 기능
![SkeletonUI](https://user-images.githubusercontent.com/84559872/168712002-0abd2fb6-f52b-4777-9085-21aad059e786.gif)
원하는 크기의 엘리먼트를 작성하여 자식 컴포넌트로 넣어주면, 해당 크기에 맞춰 스켈레톤UI 효과가 구현됩니다.

2. Refactor: Modal props 이름 변경
사용자가 state나 setState를 props로 내려줄 때의 props 네이밍을 다른 기능들과 통일시켰습니다. 
ex) handleModalClose => onClose / isModalOn => open