### PR TITLE
Feat: TransferList 기능

### DIFF
--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -11,6 +11,7 @@ import ToggleDescription from "../features/Toggle/ToggleDescription";
 import ToastDescription from "../features/Toast/ToastDescription";
 import SkeletonUIDescription from "../features/SkeletonUI/SkeletonUIDescription";
 import FeatureIntro from "../features/FeatureIntro";
+import TransferListDescription from "../features/TransferList/TransferListDescription";
 
 const container = css`
   display: flex;
@@ -32,6 +33,7 @@ const Article = () => {
         <Route path="/drawer" element={<DrawerDescription />} />
         <Route path="/toast" element={<ToastDescription />} />
         <Route path="/skeletonui" element={<SkeletonUIDescription />} />
+        <Route path="/transferlist" element={<TransferListDescription />} />
       </Routes>
     </div>
   );

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -17,6 +17,7 @@ const features = [
   "drawer",
   "toast",
   "skeletonui",
+  "transferlist",
 ];
 
 const Nav = () => {

--- a/src/features/TransferList/TransferListDemo.tsx
+++ b/src/features/TransferList/TransferListDemo.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const TransferListDemo = () => {
+  return <div>TransferListDemo</div>;
+};
+
+export default TransferListDemo;

--- a/src/features/TransferList/TransferListDemo.tsx
+++ b/src/features/TransferList/TransferListDemo.tsx
@@ -1,7 +1,252 @@
-import React from "react";
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import React, { useState } from "react";
+import { lightColor } from "../../styled";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAnglesLeft } from "@fortawesome/free-solid-svg-icons";
+import { faAngleLeft } from "@fortawesome/free-solid-svg-icons";
+import { faAngleRight } from "@fortawesome/free-solid-svg-icons";
+import { faAnglesRight } from "@fortawesome/free-solid-svg-icons";
 
-const TransferListDemo = () => {
-  return <div>TransferListDemo</div>;
+const layout = css`
+  display: flex;
+  align-items: center;
+`;
+
+const card = css`
+  width: 200px;
+  max-height: 1000px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid black;
+  background-color: white;
+`;
+
+const cardHeader = css`
+  width: 100%;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid black;
+  font-size: 24px;
+  font-weight: 600;
+`;
+
+const itemlist = css`
+  width: 100%;
+  height: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: auto;
+`;
+
+const itemContainer = css`
+  width: 100%;
+  min-height: 80px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  box-sizing: border-box;
+  :hover {
+    background-color: ${lightColor};
+  }
+`;
+
+const checkbox = css`
+  width: 20px;
+  height: 20px;
+`;
+
+const itemText = css`
+  width: 100%;
+  margin-left: 20px;
+  font-size: 24px;
+`;
+
+const buttonlist = css`
+  width: 100px;
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+const button = css`
+  width: 50px;
+  height: 50px;
+  padding: none;
+  border: none;
+  cursor: pointer;
+  :hover {
+    background-color: gray;
+  }
+  :active {
+    background-color: gray;
+  }
+`;
+
+type TransferListProps = {
+  leftTitle: string | null;
+  rightTitle: string | null;
+  leftItemlist: string[];
+  rightItemlist: string[];
+};
+
+const TransferListDemo = ({
+  leftTitle,
+  rightTitle,
+  leftItemlist,
+  rightItemlist,
+}: TransferListProps) => {
+  const [left, setLeft] = useState<string[]>(leftItemlist);
+  const [right, setRight] = useState<string[]>(rightItemlist);
+
+  const [leftChecked, setLeftChecked] = useState<boolean[]>(
+    Array(left.length).fill(false)
+  );
+
+  const [rightChecked, setRightChecked] = useState<boolean[]>(
+    Array(right.length).fill(false)
+  );
+
+  const moveCheckedLeft = () => {
+    let itemToMove: string[] = [];
+
+    for (let index = 0; index < rightChecked.length; index++) {
+      if (rightChecked[index]) {
+        itemToMove.push(right[index]);
+        setLeftChecked((leftChecked) => {
+          leftChecked.fill(false).push(false);
+          return leftChecked;
+        });
+      }
+    }
+
+    setRightChecked((rightChecked) =>
+      rightChecked.filter((checked) => !checked).fill(false)
+    );
+
+    setLeft((left) => left.concat(itemToMove));
+    setRight((right) => right.filter((_, i) => !rightChecked[i]));
+  };
+
+  const moveCheckedRight = () => {
+    let itemToMove: string[] = [];
+
+    for (let index = 0; index < leftChecked.length; index++) {
+      if (leftChecked[index]) {
+        itemToMove.push(left[index]);
+        setRightChecked((rightChecked) => {
+          rightChecked.fill(false).push(false);
+          return rightChecked;
+        });
+      }
+    }
+
+    setLeftChecked((leftChecked) =>
+      leftChecked.filter((checked) => !checked).fill(false)
+    );
+
+    setRight((right) => right.concat(itemToMove));
+    setLeft((left) => left.filter((_, i) => !leftChecked[i]));
+  };
+
+  const moveAllLeft = () => {
+    setLeft((left) => left.concat(right));
+    setRight([]);
+  };
+
+  const moveAllRight = () => {
+    setRight((right) => right.concat(left));
+    setLeft([]);
+  };
+
+  type ItemProps = {
+    item: string;
+    index: number;
+    setCheckedArr: React.Dispatch<React.SetStateAction<boolean[]>>;
+  };
+
+  const Item = ({ item, index, setCheckedArr }: ItemProps) => {
+    const uniqueId = Math.floor(Math.random() * 10000);
+
+    const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const { checked } = event.target;
+
+      if (checked) {
+        setCheckedArr((checkedArr) => {
+          checkedArr[index] = true;
+          return checkedArr;
+        });
+      } else {
+        setCheckedArr((checkedArr) => {
+          checkedArr[index] = false;
+          return checkedArr;
+        });
+      }
+    };
+
+    return (
+      <label css={itemContainer} htmlFor={`item${uniqueId}`}>
+        <input
+          css={checkbox}
+          id={`item${uniqueId}`}
+          type="checkbox"
+          onChange={onChange}
+        />
+        <span css={itemText}>{item}</span>
+      </label>
+    );
+  };
+
+  return (
+    <div css={layout}>
+      <div css={card}>
+        <div css={cardHeader}>{leftTitle}</div>
+        <div css={itemlist}>
+          {left.map((item, index) => (
+            <Item
+              key={index}
+              item={item}
+              index={index}
+              setCheckedArr={setLeftChecked}
+            />
+          ))}
+        </div>
+      </div>
+      <div css={buttonlist}>
+        <button css={button} onClick={moveAllLeft}>
+          <FontAwesomeIcon icon={faAnglesLeft} />
+        </button>
+        <button css={button} onClick={moveCheckedLeft}>
+          <FontAwesomeIcon icon={faAngleLeft} />
+        </button>
+        <button css={button} onClick={moveCheckedRight}>
+          <FontAwesomeIcon icon={faAngleRight} />
+        </button>
+        <button css={button} onClick={moveAllRight}>
+          <FontAwesomeIcon icon={faAnglesRight} />
+        </button>
+      </div>
+      <div css={card}>
+        <div css={cardHeader}>{rightTitle}</div>
+        <div css={itemlist}>
+          {right.map((item, index) => (
+            <Item
+              key={index}
+              item={item}
+              index={index}
+              setCheckedArr={setRightChecked}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default TransferListDemo;

--- a/src/features/TransferList/TransferListDescription.tsx
+++ b/src/features/TransferList/TransferListDescription.tsx
@@ -1,0 +1,17 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { layout, feature, description } from "../../styled";
+import TransferListDemo from "./TransferListDemo";
+
+const TransferListDescription = () => {
+  return (
+    <section css={layout}>
+      <div css={feature}>
+        <TransferListDemo />
+      </div>
+      <div css={description}></div>
+    </section>
+  );
+};
+
+export default TransferListDescription;

--- a/src/features/TransferList/TransferListDescription.tsx
+++ b/src/features/TransferList/TransferListDescription.tsx
@@ -4,10 +4,13 @@ import { layout, feature, description } from "../../styled";
 import TransferListDemo from "./TransferListDemo";
 
 const TransferListDescription = () => {
+  const itemlist1 = ["item1", "item2", "item3", "item4", "item5"];
+  const itemlist2 = ["item6", "item7", "item8", "item9", "item10"];
+
   return (
     <section css={layout}>
       <div css={feature}>
-        <TransferListDemo />
+        <TransferListDemo itemlist1={itemlist1} itemlist2={itemlist2} />
       </div>
       <div css={description}></div>
     </section>

--- a/src/features/TransferList/TransferListDescription.tsx
+++ b/src/features/TransferList/TransferListDescription.tsx
@@ -1,16 +1,22 @@
 /** @jsxImportSource @emotion/react */
-import { css } from "@emotion/react";
 import { layout, feature, description } from "../../styled";
 import TransferListDemo from "./TransferListDemo";
 
 const TransferListDescription = () => {
-  const itemlist1 = ["item1", "item2", "item3", "item4", "item5"];
-  const itemlist2 = ["item6", "item7", "item8", "item9", "item10"];
+  const leftTitle = "Card1";
+  const rightTitle = "Card2";
+  const leftItemlist = ["item1", "item2", "item3", "item4", "item5"];
+  const rightItemlist = ["item6", "item7", "item8", "item9", "item10"];
 
   return (
     <section css={layout}>
       <div css={feature}>
-        <TransferListDemo itemlist1={itemlist1} itemlist2={itemlist2} />
+        <TransferListDemo
+          leftTitle={leftTitle}
+          rightTitle={rightTitle}
+          leftItemlist={leftItemlist}
+          rightItemlist={rightItemlist}
+        />
       </div>
       <div css={description}></div>
     </section>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
ex) features -> main

### 변경 사항
1. Feat: TransferList 기능
![Transferlist](https://user-images.githubusercontent.com/84559872/171579101-6ff94ebe-e9dd-4f7b-b2a1-8c98dd366d35.gif)

각각의 itemlist를 작성하고, check를 할 수 있습니다.
checked된 item들을 원하는 Card로 이동시킬 수 있습니다.

props로 itemlist의 title을 수정할 수 있는 leftTitle, rightTitle가 있습니다.<br> 또한, item들의 개수와 이름을 정할 수 있는 배열 leftItemlist, rightItemlist가 존재합니다.
