### PR TITLE
Style: 페이지마다 기능 설명 구체화 완료 + Chore: Tag 내부 scroll 사용

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
       content="09ee94aad70b641ef458f957d0fab18c00662a51"
     />
     <link rel="stylesheet" href="../normalize.css" />
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="icon" href="assets/favicon.ico" type="image/x-icon" />
     <link rel="icon" sizes="32x32" href="assets/favicon-32x32.png" />
     <link rel="icon" sizes="96x96" href="assets/favicon-96x96.png" />
     <title>Joseph Design System</title>

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -21,15 +21,24 @@ const text = css`
   border-radius: 10px;
 `;
 
+const linkStyle = css`
+  text-decoration: none;
+  :link {
+    color: black;
+  }
+  :visited {
+    color: black;
+  }
+`;
 interface ItemProps {
   feature: string;
 }
 
 const Item = ({ feature }: ItemProps) => {
   return (
-    <Link to={`${feature}`} style={{ textDecoration: "none" }}>
+    <Link to={`${feature}`} css={linkStyle}>
       <div css={container}>
-        <span css={text}>{feature}</span>
+        <span css={text}>{feature.toUpperCase()}</span>
       </div>
     </Link>
   );

--- a/src/features/AutoComplete/AutoCompleteDescription.tsx
+++ b/src/features/AutoComplete/AutoCompleteDescription.tsx
@@ -1,6 +1,15 @@
 /** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
 import { layout, feature, description } from "../../styled";
 import AutoCompleteDemo from "./AutoCompleteDemo";
+
+const affordance = css`
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 const AutoCompleteDescription = () => {
   const items = ["apple", "butter", "banana", "orange"];
@@ -8,9 +17,31 @@ const AutoCompleteDescription = () => {
   return (
     <section css={layout}>
       <div css={feature}>
-        <AutoCompleteDemo items={items} />
+        <div css={affordance}>
+          <AutoCompleteDemo items={items} />
+          <span>위의 input에 아무 문자나 입력해 보세요!</span>
+        </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>AutoComplete</h3>
+        <strong>
+          AutoComplete 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+        </strong>
+        <p>
+          1. AutoComplete에서 검색 시 나올 데이터들은 <br />
+          props로 items에 문자열 배열 형태로 내려주어야 합니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`const items = ["apple", "butter", "banana", "orange"];`}</code>
+          <br />
+          <br />
+          <code>{" <AutoCompleteDemo items={items} />"}</code>
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/Drawer/DrawerDescription.tsx
+++ b/src/features/Drawer/DrawerDescription.tsx
@@ -13,6 +13,14 @@ const ButtonsLayout = css`
   grid-template-rows: repeat(3, 1fr);
 `;
 
+const affordance = css`
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 export interface DrawerProps extends React.HTMLAttributes<any> {
   title: string;
   width?: number;
@@ -23,26 +31,101 @@ const DrawerDescription = () => {
   return (
     <section css={layout}>
       <div css={feature}>
-        <div css={ButtonsLayout}>
-          <span />
-          <TopDrawerDemo title="TopDrawer" height={300}>
-            {children}
-          </TopDrawerDemo>
-          <span />
-          <LeftDrawerDemo title="LefttDrawer" width={300}>
-            {children}
-          </LeftDrawerDemo>
-          <span />
-          <RightDrawerDemo title="RightDrawer" width={100}>
-            {children}
-          </RightDrawerDemo>
-          <span />
-          <BottomDrawerDemo title="BottomDrawer" height={200}>
-            {children}
-          </BottomDrawerDemo>
+        <div css={affordance}>
+          <div css={ButtonsLayout}>
+            <span />
+            <TopDrawerDemo title="TopDrawer" height={300}>
+              {children}
+            </TopDrawerDemo>
+            <span />
+            <LeftDrawerDemo title="LefttDrawer" width={300}>
+              {children}
+            </LeftDrawerDemo>
+            <span />
+            <RightDrawerDemo title="RightDrawer" width={100}>
+              {children}
+            </RightDrawerDemo>
+            <span />
+            <BottomDrawerDemo title="BottomDrawer" height={200}>
+              {children}
+            </BottomDrawerDemo>
+          </div>
+          <span>상하좌우 방향의 버튼들을 각각 클릭해 보세요!</span>
         </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>Drawer</h3>
+        <strong>Drawer는 방향에 따라 총 4가지 종류가 존재합니다.</strong>
+        <br />
+        <strong>
+          Drawer가 나오는 방향에 따라, 너비 혹은 높이를 지정할 수 있습니다.
+        </strong>
+        <p>
+          1. 위쪽과 아래쪽에서 각각 구현되는 TopDrawerDemo와 BottomDrawerDemo는
+          높이를 지정해 줘야 합니다. <br />
+          props로 height number 값을 내려주면, 해당 높이를 가진 Drawer가
+          생성됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{"const height = 300;"}</code>
+          <br />
+          <br />
+          <code>{"<TopDrawerDemo height={height} />"}</code>
+          <br />
+          <code>{"<BottomDrawerDemo height={height} />"}</code>
+          <br />
+          <br />
+          2. 왼쪽과 오른쪽에서 각각 구현되는 LeftDrawerDemo와 RightDrawerDemo는
+          너비를 지정해 줘야 합니다. <br />
+          props로 width number 값을 내려주면, 해당 너비를 가진 Drawer가
+          생성됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{"const width = 300;"}</code>
+          <br />
+          <br />
+          <code>{"<LeftDrawerDemo width={width} />"}</code>
+          <br />
+          <code>{"<RightDrawerDemo width={width} />"}</code>
+          <br />
+          <br />
+          3. title을 지정해 줘야 합니다. <br />
+          props로 title을 문자열을 내려주면, 해당 title을 이름으로 가지고
+          Drawer를 on/off할 수 있는 버튼이 생성됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`const title = "TopDrawer";`}</code>
+          <br />
+          <br />
+          <code>{`<TopDrawerDemo title={title} />`}</code>
+          <br />
+          <br />
+          4. Drawer에 마크업을 자식컴포넌트로 넣어 원하는 디자인을 구현할 수
+          있습니다. <br />
+          미리 제작된 마크업을 Drawer의 자식 컴포넌트로 넣어 주면, 해당 코드가
+          Drawer 내부에 구현됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`import { children } from "./ChildrenExample";`}</code>
+          <br />
+          <br />
+          <code>{`<TopDrawerDemo title="TopDrawer" height={300}>`}</code>
+          <br />
+          <code> {`{children}`}</code>
+          <br />
+          <code>{`</TopDrawerDemo>`}</code>
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/DropDown/DropDownDescription.tsx
+++ b/src/features/DropDown/DropDownDescription.tsx
@@ -9,6 +9,15 @@ const container = css`
   display: flex;
   justify-content: center;
 `;
+
+const affordance = css`
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 const dropDownWidth = 200;
 
 const title = "DropDown1";
@@ -19,20 +28,69 @@ const DropDownDescription = () => {
   return (
     <section css={layout}>
       <div css={feature}>
-        <section css={container}>
-          <DropDownDemo
-            title={title}
-            dropDownItems={dropDownItems}
-            dropDownWidth={dropDownWidth}
-          />
-          <DropDownDemo
-            title="DropDown2"
-            dropDownItems={["Item1", "Item2", "Item3"]}
-            dropDownWidth={300}
-          />
-        </section>
+        <div css={affordance}>
+          <span>아래의 DropDown에 마우스 포인터를 가져다 대 보세요!</span>
+          <section css={container}>
+            <DropDownDemo
+              title={title}
+              dropDownItems={dropDownItems}
+              dropDownWidth={dropDownWidth}
+            />
+            <DropDownDemo
+              title="DropDown2"
+              dropDownItems={["Item1", "Item2", "Item3"]}
+              dropDownWidth={300}
+            />
+          </section>
+        </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>DropDown</h3>
+        <strong>
+          DropDown 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+        </strong>
+        <p>
+          1. DropDown의 너비를 지정해 줘야 합니다. <br />
+          props로 dropDownWidth에 number 값을 내려주면, 해당 너비를 가진
+          DropDown이 생성됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{"const dropDownWidth = 400;"}</code>
+          <br />
+          <br />
+          <code>{"<DropDownDemo width={dropDownWidth} />"}</code>
+          <br />
+          <br />
+          2. title을 지정해 줘야 합니다. <br />
+          props로 title을 문자열을 내려주면, 해당 제목을 가진 DropDown이
+          생성됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`const title = "DropDown1";`}</code>
+          <br />
+          <br />
+          <code>{`<DropDownDemo title={title} />`}</code>
+          <br />
+          <br />
+          3. DropDown에 나열될 아이템 이름들을 지정해 줘야 합니다. <br />
+          props로 dropDownItems 문자열 배열을 내려주면, 해당 아이템들이 나열된
+          DropDown이 생성됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`const dropDownItems = ["Item1", "Item2", "Item3", "Item4", "Item5"];`}</code>
+          <br />
+          <br />
+          <code>{`<DropDownDemo dropDownItems={dropDownItems} />`}</code>
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/Modal/ModalDescription.tsx
+++ b/src/features/Modal/ModalDescription.tsx
@@ -59,7 +59,7 @@ const ModalDescription = () => {
       <div css={description}>
         <h3>Modal</h3>
         <strong>
-          모달 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+          Modal 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
         </strong>
         <p>
           1. boolean값을 가진 state를 만들어 줘야 합니다. <br />

--- a/src/features/SkeletonUI/SkeletonUIDescription.tsx
+++ b/src/features/SkeletonUI/SkeletonUIDescription.tsx
@@ -50,7 +50,33 @@ const SkeletonUIDescription = () => {
           </SkeletonUIDemo>
         </section>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>SkeletonUI</h3>
+        <strong>
+          SkeletonUI 는 마크업을 자식컴포넌트로 넣어 원하는 디자인을 구현할 수
+          있습니다.
+        </strong>
+        <p>
+          SkeletonUI 에 마크업을 자식컴포넌트로 넣어 원하는 디자인을 구현할 수
+          있습니다. <br />
+          미리 제작된 마크업을 SkeletonUI 의 자식 컴포넌트로 넣어 주면, 해당
+          마크업 모양의 SkeletonUI 가 구현됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`import {children} from "./ChildrenExample";`}</code>
+          <br />
+          <br />
+          <code>{`<SkeletonUIDemo>`}</code>
+          <br />
+          <code> {`{children}`}</code>
+          <br />
+          <code>{`</SkeletonUIDemo>`}</code>
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/Tabs/TabsDescription.tsx
+++ b/src/features/Tabs/TabsDescription.tsx
@@ -1,6 +1,16 @@
 /** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
 import TabsDemo from "./TabsDemo";
 import { layout, feature, description } from "../../styled";
+
+const affordance = css`
+  width: 400px;
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 const TabsDescription = () => {
   const tabs = ["tab1", "tab2", "tab3"];
@@ -8,9 +18,32 @@ const TabsDescription = () => {
   return (
     <section css={layout}>
       <div css={feature}>
-        <TabsDemo tabs={tabs} />
+        <div css={affordance}>
+          <TabsDemo tabs={tabs} />
+          <span>
+            위의 tap들을 클릭하거나, 마우스 포인터를 가져다 대 보세요!
+          </span>
+        </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>Tabs</h3>
+        <strong>
+          Tabs 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+        </strong>
+        <p>
+          1. 각 Tab들에 이름을 부여하기 위해서는 props로 tabs에 문자열 배열로
+          내려주어야 합니다.
+          <br />
+          <br />
+          {"ex)"} {<code>const tabs = ["tab1", "tab2", "tab3"]</code>}
+          <br />
+          <br />
+          2. props로 내려주는 tabs 문자열 배열안의 요소 개수에 따라, tab의
+          개수도 같이 변동됩니다.
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/Tag/TagDemo.tsx
+++ b/src/features/Tag/TagDemo.tsx
@@ -14,10 +14,13 @@ const box = css`
   border: 1px solid black;
   border-radius: 20px;
   box-sizing: border-box;
+  overflow-x: overlay;
+  overflow-y: hidden;
 `;
 
 const input = css`
   width: 100%;
+  min-width: 150px;
   height: 100%;
   border: none;
   ::placeholder {

--- a/src/features/Tag/TagDescription.tsx
+++ b/src/features/Tag/TagDescription.tsx
@@ -1,7 +1,16 @@
 /** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
 import { useState } from "react";
 import TagDemo from "./TagDemo";
 import { layout, feature, description } from "../../styled";
+
+const affordance = css`
+  height: 20%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 const TagDescription = () => {
   const [tags, setTags] = useState<Array<string>>([]);
@@ -9,9 +18,36 @@ const TagDescription = () => {
   return (
     <section css={layout}>
       <div css={feature}>
-        <TagDemo tags={tags} setTags={setTags} />
+        <div css={affordance}>
+          <TagDemo tags={tags} setTags={setTags} />
+          <span>위의 input에 아무 문자를 입력하고, 엔터키를 눌러보세요!</span>
+        </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>Tag</h3>
+        <strong>
+          Tag 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+        </strong>
+        <p>
+          1. props로 tags에는 빈 배열 상태를, setTags에는 tags의 상태를 조정하는
+          setState를 내려주어야 합니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{"const [tags, setTags] = useState<Array<string>>([]);"}</code>
+          <br />
+          <br />
+          <code>{"<TagDemo tags={tags} setTags={setTags} />"}</code>
+          <br />
+          <br />
+          <br />
+          2. Tag input에 넣을 수 있는 최대 문자열 길이 한도는 10글자입니다.
+          (10글자)
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/Toast/ToastDescription.tsx
+++ b/src/features/Toast/ToastDescription.tsx
@@ -15,6 +15,14 @@ const button = css`
   color: white;
 `;
 
+const affordance = css`
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 const ToastDescription = () => {
   const [isSlideToastOn, setIsSlideToastOn] = useState(false);
 
@@ -39,28 +47,59 @@ const ToastDescription = () => {
   return (
     <section css={layout}>
       <div css={feature}>
-        <button css={button} onClick={slideToastOpen}>
-          slideToast
-        </button>
-        <button css={button} onClick={positionedToastOpen}>
-          positionedToast
-        </button>
-        <SlideToastDemo
-          width={200}
-          description="slide Toast!"
-          color="black"
-          open={isSlideToastOn}
-          onClose={slideToastClose}
-        />
-        <PositionedToastDemo
-          width={300}
-          description="This Toast is positioned."
-          color="blue"
-          open={isPositionedToastOn}
-          onClose={positionedToastClose}
-        />
+        <div css={affordance}>
+          <div>
+            <button css={button} onClick={slideToastOpen}>
+              slideToast
+            </button>
+            <button css={button} onClick={positionedToastOpen}>
+              positionedToast
+            </button>
+            <SlideToastDemo
+              width={200}
+              description="slide Toast!"
+              color="black"
+              open={isSlideToastOn}
+              onClose={slideToastClose}
+            />
+            <PositionedToastDemo
+              width={300}
+              description="This Toast is positioned."
+              color="blue"
+              open={isPositionedToastOn}
+              onClose={positionedToastClose}
+            />
+          </div>
+          <span>위 버튼들을 각각 클릭해 보세요!</span>
+        </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>Toast</h3>
+        <strong>
+          Toast는 원하는 구현 방법에 따라 총 2가지 종류가 존재합니다.
+        </strong>
+        <br />
+        <strong>
+          Toast 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+        </strong>
+        <p>
+          1. boolean값을 가진 state를 만들어 줘야 합니다. <br />
+          <br />
+          2. Toast를 소거하는 상황을 위해 false값으로 바꿔주는 handler를
+          작성해줘야 합니다. <br />
+          <br />
+          3. Toast을 생성하기 위해 true값으로 바꿔주는 handler를 작성해줘야
+          합니다.
+          <br />
+          <br />
+          4. ToastDemo에 props로 <code>open</code>, <code>onClose</code> 두
+          가지를 내려줘야 합니다. <br />
+          <br />
+          5. <code>open</code>에는 Toast 구현 유무를 결정하는 boolean 상태값을,
+          <code>onClose</code>에는 state를 false로 만들어주는 핸들러를 내려줘야
+          합니다.
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/Toggle/ToggleDescription.tsx
+++ b/src/features/Toggle/ToggleDescription.tsx
@@ -3,15 +3,46 @@ import { css } from "@emotion/react";
 import { layout, feature, description } from "../../styled";
 import ToggleDemo from "./ToggleDemo";
 
+const affordance = css`
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 const ToggleDescription = () => {
   const height = 50;
 
   return (
     <section css={layout}>
       <div css={feature}>
-        <ToggleDemo height={height} />
+        <div css={affordance}>
+          <ToggleDemo height={height} />
+          <span>위의 Toggle을 클릭해 보세요!</span>
+        </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>Toggle</h3>
+        <strong>
+          Toggle 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+        </strong>
+        <p>
+          1. Toggle의 높이를 지정해 줘야 합니다. <br />
+          props로 height에 number 값을 내려주면, 해당 높이를 가진 Toggle이
+          생성됩니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{"const height = 50;"}</code>
+          <br />
+          <br />
+          <code>{"<ToggleDemo height={height} />"}</code>
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/features/TransferList/TransferListDescription.tsx
+++ b/src/features/TransferList/TransferListDescription.tsx
@@ -1,6 +1,14 @@
 /** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
 import { layout, feature, description } from "../../styled";
 import TransferListDemo from "./TransferListDemo";
+
+const affordance = css`
+  height: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
 
 const TransferListDescription = () => {
   const leftTitle = "Card1";
@@ -13,14 +21,67 @@ const TransferListDescription = () => {
   return (
     <section css={layout}>
       <div css={feature}>
-        <TransferListDemo
-          leftTitle={leftTitle}
-          rightTitle={rightTitle}
-          leftItemlist={leftItemlist}
-          rightItemlist={rightItemlist}
-        />
+        <div css={affordance}>
+          <TransferListDemo
+            leftTitle={leftTitle}
+            rightTitle={rightTitle}
+            leftItemlist={leftItemlist}
+            rightItemlist={rightItemlist}
+          />
+          <p>
+            <br />
+            <span>
+              1. 아이템들을 클릭하면, 아이템 옆의 체크박스가 체크 됩니다.
+            </span>
+            <br />
+            <span>
+              2. 중간에 정렬된 화살표 버튼을 클릭하여 아이템들을 옮겨 보세요!
+            </span>
+          </p>
+        </div>
       </div>
-      <div css={description}></div>
+      <div css={description}>
+        <h3>TransferList</h3>
+        <strong>
+          TransferList 기능을 사용하기 위해서는, 아래 내용을 충족해야 합니다.
+        </strong>
+        <p>
+          1. TransferList 내부의 좌우 Card들의 title을 지정해 줘야 합니다.{" "}
+          <br />
+          props로 문자열을 내려주면, 각 Card의 header에 제목이 생성됩니다.
+          <br />
+          <br />
+          왼쪽 Card는 leftTitle, 오른쪽 Card는 rightTitle을 props로 내려줍니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`const leftTitle = "Card1";`}</code>
+          <br />
+          <code>{`const rightTitle = "Card2";`}</code>
+          <br />
+          <br />
+          <code>{`<TransferListDemo leftTitle={leftTitle} rightTitle={rightTitle}/>`}</code>
+          <br />
+          <br />
+          2. TransferList의 양쪽 Card에 나열될 아이템 이름들을 지정해 줘야
+          합니다. <br />
+          왼쪽 Card는 leftItemlist, 오른쪽 Card는 rightItemlist에 props로 문자열
+          배열을 내려줍니다.
+          <br />
+          <br />
+          {"ex)"}
+          <br />
+          <code>{`const leftItemlist = ["item1", "item2", "item3", "item4", "item5"];`}</code>
+          <br />
+          <code>{`const rightItemlist = ["item6", "item7", "item8", "item9", "item10"];`}</code>
+          <br />
+          <br />
+          <code>{`<TransferListDemo leftItemlist={leftItemlist} rightItemlist={rightItemlist} />`}</code>
+          <br />
+          <br />
+        </p>
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 스타일 변경

### 반영 브랜치
ex) features-> main

### 변경 사항
1. Style: 페이지마다 기능 설명 구체화 완료
![image](https://user-images.githubusercontent.com/84559872/173234691-360b87ac-6e55-45f6-b9be-da67600d99d5.png)
기능 사용 페이지의 우측에 대략적인 설명서를 작성하였습니다.
좌측의 기능 묘사 부분의 위쪽 혹은 아래쪽에 affordance를 작성했습니다.<br><br>
2. Chore: Tag가 일정이상으로 많아질 경우 scroll을 사용하는것으로 수정
이전에 자식컴포넌트 Tag를 부모컴포넌트 크기 이상으로 작성하면,
border를 넘어 Tag가 생성되었습니다.
이를 방지하고자 부모컴포넌트 크기를 초과할 시 scroll이 생성되도록 조치하였습니다.<br><br>
3. 그밖에
- Nav바의 item 텍스트 대문자로 통일하였습니다.
- Nav바의 LINK태그 href 속성에 따른 글자색 변화 제거하였습니다.
- index html 파일의 favicon href 주소를 구체적으로 수정하였습니다.